### PR TITLE
Add newlines in strings

### DIFF
--- a/src/redis.nim
+++ b/src/redis.nim
@@ -239,9 +239,13 @@ proc readSingleString(
   var numBytes = parseInt(line.substr(1))
   if numBytes == -1:
     return
-
+  
   var s = await r.managedRecv(numBytes + 2)
-  result = some(strip(s))
+  if s[^1] in NewLines:
+    s = s[0 ..< ^1]
+  if s[^1] == '\c':
+    s = s[0 ..< ^1]
+  result = some(s)
 
 proc readSingleString(r: Redis | AsyncRedis): Future[RedisString] {.multisync.} =
   # TODO: Rename these style of procedures to `processSingleString`?


### PR DESCRIPTION
I am not sure if that's the right fix: it seems to work for me, but it's a hack.

Anyway, without something like that, currently strings with `\r\n` inside are trimmed with  lrange, which seems wrong: the node lib seems to load them