### PR TITLE
pfcount supports single and multiple keys

### DIFF
--- a/src/redis.nim
+++ b/src/redis.nim
@@ -1075,6 +1075,11 @@ proc pfcount*(r: Redis | AsyncRedis, key: string): Future[RedisInteger] {.multis
   await r.sendCommand("PFCOUNT", key)
   result = await r.readInteger()
 
+proc pfcount*(r: Redis | AsyncRedis, keys: seq[string]): Future[RedisInteger] {.multisync.} =
+  ## Count approximate number of elements in 'HyperLogLog'
+  await r.sendCommand("PFCOUNT", keys)
+  result = await r.readInteger()
+
 proc pfmerge*(r: Redis | AsyncRedis, destination: string, sources: seq[string]): Future[void] {.multisync.} =
   ## Merge several source HyperLogLog's into one specified by destKey
   await r.sendCommand("PFMERGE", destination, sources)

--- a/tests/main.nim
+++ b/tests/main.nim
@@ -88,6 +88,13 @@ suite "redis tests":
 
     check r.llen("redisTest:pushEntriesToList") == 5
 
+  test "pfcount supports single key and multiple keys":
+    discard r.pfadd("redisTest:pfcount1", @["foo"])
+    check r.pfcount("redisTest:pfcount1") == 1
+
+    discard r.pfadd("redisTest:pfcount2", @["bar"])
+    check r.pfcount(@["redisTest:pfcount1", "redisTest:pfcount2"]) == 2
+
   # TODO: Ideally tests for all other procedures, will add these in the future
 
   # delete all keys in the DB at the end of the tests


### PR DESCRIPTION
Calling `pfcount` with a single key is implemented, however redis also supports calling `pfcount` with multiple keys, see https://redis.io/commands/pfcount