### PR TITLE
import std/net to allow for local 'net' module

### DIFF
--- a/src/redis.nim
+++ b/src/redis.nim
@@ -35,7 +35,7 @@
 ##
 ##    waitFor main()
 
-import net, asyncdispatch, asyncnet, os, strutils, parseutils, deques, options
+import std/net, asyncdispatch, asyncnet, os, strutils, parseutils, deques, options
 
 const
   redisNil* = "\0\0"


### PR DESCRIPTION
`src/a.nim` requires `src/net.nim` while `src/config.nim` requires redis. this worked fine until `nimble test` where the require redis would load redis, and the `require net` in redis would find the local net.nim instead of the standard net. hat tip to Yardanico on freenode #nim for suggesting the canonical name of `std/net`