### PR TITLE
Allow for subscribing to multiple channels

### DIFF
--- a/src/redis.nim
+++ b/src/redis.nim
@@ -1135,9 +1135,15 @@ proc publish*(r: Redis | AsyncRedis, channel: string, message: string): Future[R
 #   return ???
 
 proc subscribe*(r: AsyncRedis, channel: string) {.async.} =
-  ## Listen for messages published to the given channels
+  ## Listen for messages published to the given channel
   await r.sendCommand("SUBSCRIBE", @[channel])
   let commandback = await r.readNext()
+
+proc subscribe*(r: AsyncRedis, channels: seq[string]) {.async.} =
+  ## Listen for messages published to the given channels
+  await r.sendCommand("SUBSCRIBE", @[channel])
+  for c in channels:
+    let commandback = await r.readNext()
 
 # proc unsubscribe*(r: Redis, [channel: openarray[string], : string): ???? =
 #   ## Stop listening for messages posted to the given channels

--- a/src/redis.nim
+++ b/src/redis.nim
@@ -1141,7 +1141,7 @@ proc subscribe*(r: AsyncRedis, channel: string) {.async.} =
 
 proc subscribe*(r: AsyncRedis, channels: seq[string]) {.async.} =
   ## Listen for messages published to the given channels
-  await r.sendCommand("SUBSCRIBE", @[channel])
+  await r.sendCommand("SUBSCRIBE", @[channels])
   for c in channels:
     let commandback = await r.readNext()
 


### PR DESCRIPTION
Currently we can only subscribe to a single `channel` with the `subscribe()`. This PR allows the user to subscribe to multiple channels - just like https://redis.io/commands/subscribe.

```nim
import redis, asyncdispatch

var isSub: bool
var c: AsyncRedis

proc dd() {.async.} =

  while true:
    if not isSub:
      c = await openAsync()
      await c.subscribe(@["files", "users"])
      isSub = true

    let data = await c.nextMessage()
    echo $data

when isMainModule:
  asyncCheck dd()
  runForever()
```

```bash
$ redis-cli
#Received
publish files newFile
#Not received
publish ula bla
#Received
publish users John
```