### PR TITLE
Revert "Allow for subscribing to multiple channels"

### DIFF
--- a/src/redis.nim
+++ b/src/redis.nim
@@ -1135,15 +1135,9 @@ proc publish*(r: Redis | AsyncRedis, channel: string, message: string): Future[R
 #   return ???
 
 proc subscribe*(r: AsyncRedis, channel: string) {.async.} =
-  ## Listen for messages published to the given channel
+  ## Listen for messages published to the given channels
   await r.sendCommand("SUBSCRIBE", @[channel])
   let commandback = await r.readNext()
-
-proc subscribe*(r: AsyncRedis, channels: seq[string]) {.async.} =
-  ## Listen for messages published to the given channels
-  await r.sendCommand("SUBSCRIBE", @[channels])
-  for c in channels:
-    let commandback = await r.readNext()
 
 # proc unsubscribe*(r: Redis, [channel: openarray[string], : string): ???? =
 #   ## Stop listening for messages posted to the given channels


### PR DESCRIPTION
Reverts nim-lang/redis#28

@dom96 - I made a mistake in Githubs web UI! This PR fails. The new proc passes the `channel`-param inside a `seq[string]` which creates a `seq[seq[string]]` since it's already a `seq[string]`.

```nim
await r.sendCommand("SUBSCRIBE", @[channels])
# => Error: type mismatch: got <AsyncRedis, string, seq[seq[string]]>
```
should be
```nim
await r.sendCommand("SUBSCRIBE", channels)
```