### PR TITLE
hotfix: wrong type in PR #28 - Allow for subscribing to multiple channels

### DIFF
--- a/src/redis.nim
+++ b/src/redis.nim
@@ -1141,7 +1141,7 @@ proc subscribe*(r: AsyncRedis, channel: string) {.async.} =
 
 proc subscribe*(r: AsyncRedis, channels: seq[string]) {.async.} =
   ## Listen for messages published to the given channels
-  await r.sendCommand("SUBSCRIBE", @[channels])
+  await r.sendCommand("SUBSCRIBE", channels)
   for c in channels:
     let commandback = await r.readNext()
 


### PR DESCRIPTION
My PR #28 used a wrong type (#29).

> The new proc passes the channel-param inside a seq[string] which creates a seq[seq[string]] since it's already a seq[string].
>
> ```nim
> await r.sendCommand("SUBSCRIBE", @[channels])
> # => Error: type mismatch: got <AsyncRedis, string, seq[seq[string]]>
> ```
> should be
> ```nim
> await r.sendCommand("SUBSCRIBE", channels)
> ```

ping @dom96 