### PR TITLE
Add username/password `auth` procedure

### DIFF
--- a/src/redis.nim
+++ b/src/redis.nim
@@ -1195,6 +1195,11 @@ proc auth*(r: Redis | AsyncRedis, password: string): Future[void] {.multisync.} 
   await r.sendCommand("AUTH", password)
   raiseNoOK(r, await r.readStatus())
 
+proc auth*(r: Redis | AsyncRedis, username: string, password: string): Future[void] {.multisync.} =
+  ## Authenticate to a server that uses Redis ACLs
+  await r.sendCommand("AUTH", @[username, password])
+  raiseNoOK(r, await r.readStatus())
+
 proc echoServ*(r: Redis | AsyncRedis, message: string): Future[RedisString] {.multisync.} =
   ## Echo the given string
   await r.sendCommand("ECHO", message)


### PR DESCRIPTION
This allows for authentication with Redis >= 6 servers that use ACLs.