### PR TITLE
disconnect proc without sending QUIT command

### DIFF
--- a/src/redis.nim
+++ b/src/redis.nim
@@ -1229,8 +1229,13 @@ proc ping*(r: Redis | AsyncRedis): Future[RedisStatus] {.multisync.} =
   await r.sendCommand("PING")
   result = await r.readStatus()
 
-proc quit*(r: Redis | AsyncRedis): Future[void] {.multisync.} =
+proc close*(r: Redis | AsyncRedis): Future[void] {.multisync.} =
   ## Close the connection
+  r.socket.close()
+
+proc quit*(r: Redis | AsyncRedis): Future[void] {.multisync.} =
+  ## Close the connection with using QUIT command
+  ## Note: This command is regarded as deprecated since Redis version 7.2.0.
   await r.sendCommand("QUIT")
   raiseNoOK(r, await r.readStatus())
   r.socket.close()


### PR DESCRIPTION
When I connected to a Redis fork called [Redka](https://github.com/nalgeon/redka) a while ago using this library, an error occurred because the QUIT command had already been removed.
Later, I learned from the official documentation that the QUIT command has been deprecated in Redis 7.2.0 and that it is now better to simply disconnect the Websocket.
so this library is needing improvement.