### PR TITLE
fix: preserve leading/trailing whitespace in bulk string replies

### DIFF
--- a/src/redis.nim
+++ b/src/redis.nim
@@ -265,8 +265,11 @@ proc readSingleString(
   if numBytes == -1:
     return
 
+  # Bulk strings are binary safe; drop only the trailing CRLF, never
+  # whitespace belonging to the value itself.
   var s = await r.managedRecv(numBytes + 2)
-  result = some(strip(s))
+  s.setLen(numBytes)
+  result = some(s)
 
 proc readSingleString(r: Redis | AsyncRedis): Future[RedisString] {.multisync.} =
   # TODO: Rename these style of procedures to `processSingleString`?

--- a/tests/main.nim
+++ b/tests/main.nim
@@ -13,6 +13,18 @@ template syncTests() =
 
     check actual == expected
 
+  test "get returns values byte-for-byte":
+    # Regression test for https://github.com/nim-lang/redis/issues/44:
+    # bulk replies were passed through strip(), corrupting values with
+    # leading/trailing whitespace. Bulk strings are binary safe, so
+    # embedded CRLF and NUL bytes must survive the round trip too.
+    const expected = " \t padded\r\nvalue\0 \n "
+
+    r.setk("redisTests:whitespacePreserved", expected)
+    let actual = r.get("redisTests:whitespacePreserved")
+
+    check actual == expected
+
   test "increment key by one":
     const expected = 3
 


### PR DESCRIPTION
## Summary

`readSingleString` removed the trailing CRLF of a bulk reply with `strip()`, which also removes all leading and trailing whitespace and NUL bytes belonging to the value itself. Any padded or binary value was silently mangled on read: `get` of a value stored as `" padded "` returned `"padded"`.

Since the send path is length-prefixed and binary safe, the client could store values it then could not read back correctly. Both `Redis` and `AsyncRedis` were affected, as were all commands returning a `RedisString` and bulk elements inside array replies.

## Fix

The reply is read as exactly `numBytes + 2` bytes (value plus CRLF), so the length is already known: truncate with `s.setLen(numBytes)` to drop exactly the two protocol bytes instead of calling `strip()`.

No API change; the returned value now simply matches what was stored.

## Tests

Adds a round-trip regression test to the sync suite covering leading/trailing whitespace, an embedded CRLF, and a NUL byte. Verified green against a real Redis server in the sync, async, and threaded suites (the parsing code is shared via `multisync`).

Fixes #44