### PR TITLE
fix: raise RedisError when the server closes the connection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
       - run:
           name: test
           command: nim c -r tests/main.nim
+      - run:
+          name: test closed connection handling
+          command: nim c -r tests/tclosedconn.nim
   build_alpine:
     working_directory: /usr/src/redis
     docker:
@@ -20,6 +23,9 @@ jobs:
       - run:
           name: test
           command: nim c -r tests/main.nim
+      - run:
+          name: test closed connection handling
+          command: nim c -r tests/tclosedconn.nim
 workflows:
   version: 2
   build_and_test:

--- a/src/redis.nim
+++ b/src/redis.nim
@@ -173,13 +173,19 @@ proc managedRecv(
 
 proc managedRecvLine(r: Redis | AsyncRedis): Future[string] {.multisync.} =
   if r.pipeline.enabled:
-    result = ""
+    return ""
+
+  when r is Redis:
+    let taintedResult: TaintedString = recvLine(r.socket)
+    result = $taintedResult
   else:
-    when r is Redis:
-      let taintedResult: TaintedString = recvLine(r.socket)
-      result = $taintedResult
-    else:
-      result = await recvLine(r.socket)
+    result = await recvLine(r.socket)
+
+  # recvLine returns "" only when the peer closed the connection; an empty
+  # protocol line would be returned as "\r\L". Raise here so callers can
+  # treat an empty result as the pipelining dummy.
+  if result.len == 0:
+    raiseRedisError(r, "Server closed connection prematurely")
 
 proc raiseInvalidReply(r: Redis | AsyncRedis, expected, got: char) =
   raiseReplyError(r,
@@ -1331,7 +1337,9 @@ proc shutdown*(r: Redis | AsyncRedis): Future[void] {.multisync.} =
     if len(s) != 0:
       raiseRedisError(r, s)
   else:
-    let s = await managedRecvLine(r)
+    # Read the socket directly: an empty line (EOF) is the expected
+    # outcome of SHUTDOWN, not an error.
+    let s = await recvLine(r.socket)
     if len(s) != 0:
       raiseRedisError(r, s)
     finaliseCommand(r)

--- a/tests/tclosedconn.nim
+++ b/tests/tclosedconn.nim
@@ -1,0 +1,66 @@
+# This test suite uses an in-process mock that accepts a connection, 
+# reads one command and closes the socket without replying. Each 
+# command below should raise RedisError; today they all return
+# dummy values, so every test fails.
+
+import asyncnet, asyncdispatch, strutils, unittest, redis
+
+const mockPort = 5314.Port
+
+proc mockDroppingServer() {.async.} =
+  var server = newAsyncSocket()
+  server.setSockOpt(OptReuseAddr, true)
+  server.bindAddr(mockPort)
+  server.listen()
+
+  while true:
+    let c = await server.accept()
+    # Read one complete RESP request, whatever the command or arity:
+    # "*<argc>" followed by argc bulk strings of two lines each
+    # ("$<len>", payload). Draining the full request before closing
+    # makes the close a clean EOF for the client rather than a reset.
+    let header = await c.recvLine()
+    if header.len > 1 and header[0] == '*':
+      for _ in 1 .. 2 * parseInt(header.substr(1)):
+        discard await c.recvLine()
+    c.close()
+
+suite "closed connection handling":
+  asyncCheck mockDroppingServer()
+
+  test "get raises on closed connection instead of returning \"\"":
+    proc run() {.async.} =
+      let r = await openAsync("localhost", mockPort)
+      expect RedisError:
+        discard await r.get("some:key")
+    waitFor run()
+
+  test "exists raises on closed connection instead of returning false":
+    proc run() {.async.} =
+      let r = await openAsync("localhost", mockPort)
+      expect RedisError:
+        discard await r.exists("some:key")
+    waitFor run()
+
+  test "ttl raises on closed connection instead of returning -1":
+    # The worst case: -1 is also a legitimate TTL reply (no expiration),
+    # so the old dummy value was indistinguishable from real data.
+    proc run() {.async.} =
+      let r = await openAsync("localhost", mockPort)
+      expect RedisError:
+        discard await r.ttl("some:key")
+    waitFor run()
+
+  test "keys raises on closed connection instead of returning @[]":
+    proc run() {.async.} =
+      let r = await openAsync("localhost", mockPort)
+      expect RedisError:
+        discard await r.keys("*")
+    waitFor run()
+
+  test "setk raises on closed connection instead of succeeding":
+    proc run() {.async.} =
+      let r = await openAsync("localhost", mockPort)
+      expect RedisError:
+        await r.setk("some:key", "value")
+    waitFor run()


### PR DESCRIPTION
## Summary

When the server closes the connection, `recvLine` returns an empty string, and every reply reader treated that as the pipelining dummy without checking whether pipelining was actually enabled. Against a dead connection, `get` returned `""`, `exists` returned `false`, `ttl` returned `-1` (indistinguishable from a real no-expiration reply), `keys` returned `@[]`, and `setk` raised a misleading `ReplyError` about `"PIPELINED"`. The existing "Server closed connection prematurely" checks in `parseStatus`/`parseInteger` were unreachable.

## Fix

Detect EOF centrally in `managedRecvLine`, the one place where the pipelining dummy and a closed connection were conflated, and raise `RedisError("Server closed connection prematurely")` there. The readers' empty-line branches are unchanged and now apply only to pipelining, as originally intended. 

`shutdown` expects EOF as its success outcome, so its async branch now reads the socket directly, mirroring the existing sync branch.

Both `Redis` and `AsyncRedis` are covered since the readers are shared via `multisync`. No API change: only the dead-connection behavior changes, from silent dummy values to the documented `RedisError`.

## Tests

Adds `tests/tclosedconn.nim`: an in-process mock reads one complete RESP request and closes the socket without replying, indistinguishable from a server dying mid-request. Tests assert `RedisError` for `get`, `exists`, `ttl`, `keys`, and `setk`. The mock parses the request per the RESP protocol rather than assuming any client framing, and needs no redis-server, so it is wired into CI as a separate step. 

Fixes #46