### PR TITLE
fix: stop dropping pipeline results that resemble status replies

### DIFF
--- a/src/redis.nim
+++ b/src/redis.nim
@@ -370,8 +370,10 @@ proc flushPipeline*(r: Redis | AsyncRedis, wasMulti = false): Future[RedisList] 
   for i in 0..tot-1:
     var ret = await r.readNext()
     for item in ret:
-     if not (item.contains("OK") or item.contains("QUEUED")):
-       result.add(item)
+      # Filter out whole status replies only; a data value merely
+      # containing "OK" or "QUEUED" must be kept.
+      if not (item == "OK" or item == "QUEUED"):
+        result.add(item)
 
   r.pipeline.expected = 0
 

--- a/src/redis.nim
+++ b/src/redis.nim
@@ -187,6 +187,77 @@ proc managedRecvLine(r: Redis | AsyncRedis): Future[string] {.multisync.} =
   if result.len == 0:
     raiseRedisError(r, "Server closed connection prematurely")
 
+type
+  RespKind = enum
+    ## Internal RESP reply classification, used to filter pipeline
+    ## results by type instead of by value. Not exported: the public API
+    ## keeps returning flat strings.
+    respStatus, respError, respInteger, respBulk, respNilBulk,
+    respNilArray, respArray
+
+  RespReply = object
+    kind: RespKind
+    value: string            # status/error/bulk text or rendered integer
+    elements: seq[RespReply] # respArray only
+
+proc readResp(r: Redis): RespReply {.gcsafe.}
+proc readResp(r: AsyncRedis): Future[RespReply] {.gcsafe.}
+proc readResp(r: Redis | AsyncRedis): Future[RespReply] {.multisync.} =
+  ## Read one complete reply, classifying it by its RESP type marker so
+  ## that status acknowledgments can be told apart from data replies
+  ## that happen to carry the same text.
+  let line = await r.managedRecvLine()
+  if line.len == 0:
+    raiseReplyError(r, "readResp called while pipelining is enabled")
+
+  case line[0]
+  of '+':
+    result = RespReply(kind: respStatus, value: line.substr(1))
+  of '-':
+    # Keep the full error line, matching the message parseStatus raises.
+    result = RespReply(kind: respError, value: strip(line))
+  of ':':
+    var num: BiggestInt
+    if parseBiggestInt(line, num, 1) == 0:
+      raiseReplyError(r, "Unable to parse integer.")
+    result = RespReply(kind: respInteger, value: $num)
+  of '$':
+    let numBytes = parseInt(line.substr(1))
+    if numBytes == -1:
+      result = RespReply(kind: respNilBulk)
+    else:
+      var s = await r.managedRecv(numBytes + 2)
+      s.setLen(numBytes)
+      result = RespReply(kind: respBulk, value: s)
+  of '*':
+    let numElems = parseInt(line.substr(1))
+    if numElems == -1:
+      result = RespReply(kind: respNilArray)
+    else:
+      result = RespReply(kind: respArray, elements: @[])
+      for _ in 1 .. numElems:
+        when r is Redis:
+          result.elements.add(r.readResp())
+        else:
+          result.elements.add(await r.readResp())
+  else:
+    raiseReplyError(r, "readResp failed on line: " & line)
+
+proc appendData(r: Redis | AsyncRedis, reply: RespReply, into: var RedisList) =
+  ## Flatten a reply into the legacy string list, dropping status
+  ## acknowledgments by type. Mirrors the historical flattening: nested
+  ## arrays are spliced into the parent, a nil bulk becomes redisNil, a
+  ## nil array contributes nothing, and error replies raise.
+  case reply.kind
+  of respStatus: discard
+  of respError: raiseRedisError(r, reply.value)
+  of respInteger, respBulk: into.add(reply.value)
+  of respNilBulk: into.add(redisNil)
+  of respNilArray: discard
+  of respArray:
+    for element in reply.elements:
+      appendData(r, element, into)
+
 proc raiseInvalidReply(r: Redis | AsyncRedis, expected, got: char) =
   raiseReplyError(r,
           "Expected '$1' at the beginning of a status reply got '$2'" %
@@ -368,12 +439,11 @@ proc flushPipeline*(r: Redis | AsyncRedis, wasMulti = false): Future[RedisList] 
   var tot = r.pipeline.expected
 
   for i in 0..tot-1:
-    var ret = await r.readNext()
-    for item in ret:
-      # Filter out whole status replies only; a data value merely
-      # containing "OK" or "QUEUED" must be kept.
-      if not (item == "OK" or item == "QUEUED"):
-        result.add(item)
+    # Read each reply in typed form and filter status acknowledgments by
+    # their RESP type, so data replies whose text happens to be "OK" or
+    # "QUEUED" are preserved.
+    let reply = await r.readResp()
+    appendData(r, reply, result)
 
   r.pipeline.expected = 0
 

--- a/tests/main.nim
+++ b/tests/main.nim
@@ -112,26 +112,61 @@ template syncTests() =
     # pipeline results were filtered with contains("OK")/contains("QUEUED"),
     # a substring match, so legitimate values were silently dropped and
     # later results shifted position.
-    r.setk("redisTests:pipeline:lookup", "LOOKUP")
-    r.setk("redisTests:pipeline:jobs", "QUEUED_JOBS")
-    r.setk("redisTests:pipeline:plain", "plain")
+    const
+      lookupKey = "redisTests:pipeline:lookup"
+      jobsKey = "redisTests:pipeline:jobs"
+      plainKey = "redisTests:pipeline:plain"
+
+    r.setk(lookupKey, "LOOKUP")
+    r.setk(jobsKey, "QUEUED_JOBS")
+    r.setk(plainKey, "plain")
 
     r.startPipelining()
-    discard r.get("redisTests:pipeline:lookup")
-    discard r.get("redisTests:pipeline:jobs")
-    discard r.get("redisTests:pipeline:plain")
+    discard r.get(lookupKey)
+    discard r.get(jobsKey)
+    discard r.get(plainKey)
     let res = r.flushPipeline()
 
     check res == @["LOOKUP", "QUEUED_JOBS", "plain"]
 
+  test "flushPipeline preserves values equal to OK or QUEUED":
+    # Status acknowledgments are filtered by RESP reply type, so a data
+    # reply whose text is exactly "OK" or "QUEUED" must survive.
+    const
+      okKey = "redisTests:pipeline:okval"
+      queuedKey = "redisTests:pipeline:queuedval"
+
+    r.setk(okKey, "OK")
+    r.setk(queuedKey, "QUEUED")
+
+    r.startPipelining()
+    discard r.get(okKey)
+    discard r.get(queuedKey)
+    let res = r.flushPipeline()
+
+    check res == @["OK", "QUEUED"]
+
   test "exec preserves values containing OK":
-    r.setk("redisTests:multi:broken", "BROKEN")
+    const brokenKey = "redisTests:multi:broken"
+
+    r.setk(brokenKey, "BROKEN")
 
     r.multi()
-    discard r.get("redisTests:multi:broken")
+    discard r.get(brokenKey)
     let res = r.exec()
 
     check res == @["BROKEN"]
+
+  test "exec preserves values equal to OK":
+    const okKey = "redisTests:multi:okval"
+
+    r.setk(okKey, "OK")
+
+    r.multi()
+    discard r.get(okKey)
+    let res = r.exec()
+
+    check res == @["OK"]
 
   # TODO: Ideally tests for all other procedures, will add these in the future
 

--- a/tests/main.nim
+++ b/tests/main.nim
@@ -107,6 +107,32 @@ template syncTests() =
     discard r.pfadd("redisTest:pfcount2", @["bar"])
     check r.pfcount(@["redisTest:pfcount1", "redisTest:pfcount2"]) == 2
 
+  test "flushPipeline preserves values containing OK or QUEUED":
+    # Regression test for https://github.com/nim-lang/redis/issues/48:
+    # pipeline results were filtered with contains("OK")/contains("QUEUED"),
+    # a substring match, so legitimate values were silently dropped and
+    # later results shifted position.
+    r.setk("redisTests:pipeline:lookup", "LOOKUP")
+    r.setk("redisTests:pipeline:jobs", "QUEUED_JOBS")
+    r.setk("redisTests:pipeline:plain", "plain")
+
+    r.startPipelining()
+    discard r.get("redisTests:pipeline:lookup")
+    discard r.get("redisTests:pipeline:jobs")
+    discard r.get("redisTests:pipeline:plain")
+    let res = r.flushPipeline()
+
+    check res == @["LOOKUP", "QUEUED_JOBS", "plain"]
+
+  test "exec preserves values containing OK":
+    r.setk("redisTests:multi:broken", "BROKEN")
+
+    r.multi()
+    discard r.get("redisTests:multi:broken")
+    let res = r.exec()
+
+    check res == @["BROKEN"]
+
   # TODO: Ideally tests for all other procedures, will add these in the future
 
   # delete all keys in the DB at the end of the tests


### PR DESCRIPTION
## Summary

`flushPipeline` filtered status acknowledgments out of pipeline results with `contains("OK")` / `contains("QUEUED")`, a substring match over the flattened reply strings. Any legitimate data value containing those strings ("TOKYO", "BROKEN", "QUEUED_JOBS", tokens, uppercased IDs) was silently removed, and because callers match pipeline results to commands by position, every later result was attributed to the wrong command. `exec()` returns its results through the same path, so MULTI/EXEC was affected identically.

## Fix

Two steps, one per commit:

1. Replace the substring match with whole-string equality. This fixes the common accidental collisions but still cannot distinguish a data reply whose text is exactly "OK" or "QUEUED" from a real status, since reply types were erased during parsing.
2. Read pipeline replies through an internal type-aware parser and drop acknowledgments by their RESP marker (`+`) instead of by value. A bulk reply survives whatever its text: `GET` of a value stored as "OK" now round-trips through a pipeline correctly.

## Compatibility

No public API change. 

## Tests

Adds regression tests to the sync suite that verify `flushPipeline` preserves values containing the magic strings ("LOOKUP", "QUEUED_JOBS") and values exactly equal to them ("OK", "QUEUED").

Fixes #48